### PR TITLE
feature: add `put_variables/2` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ query =
 Shopify.GraphQL.send(query, access_token: "...", shop: "myshop"))
 ```
 
-You can manage variables using the `Shopify.GraphQL.put_variable/3` function.
+You can manage variables using the `Shopify.GraphQL.put_variable/3` and 
+`Shopify.GraphQL.put_variables/2` functions.
 
 ```elixir
 query =
@@ -50,6 +51,10 @@ query =
 
 query
 |> Shopify.GraphQL.put_variable(:customerId, "gid://shopify/Customer/12195007594552")
+|> Shopify.GraphQL.send(access_token: "...", shop: "myshop")
+
+query
+|> Shopify.GraphQL.put_variables(%{customerId: "gid://shopify/Customer/12195007594552"})
 |> Shopify.GraphQL.send(access_token: "...", shop: "myshop")
 ```
 

--- a/lib/shopify/graphql.ex
+++ b/lib/shopify/graphql.ex
@@ -24,6 +24,16 @@ defmodule Shopify.GraphQL do
     to: Operation
 
   @doc """
+  Add variables to the operation.
+
+  It's possible to pass either a `Shopify.GraphQL.Operation` struct or, as a
+  convenience, a binary query.
+  """
+  @spec put_variables(binary | Operation.t(), map) :: Operation.t()
+  defdelegate put_variables(operation_or_query, map),
+    to: Operation
+
+  @doc """
   Send a GraphQL operation to Shopify.
 
   It's possible to send either a `Shopify.GraphQL.Operation` struct or, as a

--- a/lib/shopify/graphql/operation.ex
+++ b/lib/shopify/graphql/operation.ex
@@ -17,4 +17,15 @@ defmodule Shopify.GraphQL.Operation do
 
     %{ operation | variables: variables }
   end
+
+  @spec put_variables(binary | t, map) :: t
+  def put_variables(query, variables) when is_binary(query) do
+    put_variables(%__MODULE__{query: query}, variables)
+  end
+
+  def put_variables(operation, variables) do
+    variables = Map.merge(operation.variables, variables)
+
+    %{operation | variables: variables}
+  end
 end

--- a/test/shopify/graphql_test.exs
+++ b/test/shopify/graphql_test.exs
@@ -7,6 +7,58 @@ defmodule Shopify.GraphQLTest do
 
   @not_ok_resp %{ body: "{\"ok\":false}", headers: [], status_code: 400 }
 
+  describe "put_variables/2" do
+    test "puts variables when query is provided" do
+      query = """
+      {
+        shop {
+          name
+        }
+      }
+      """
+
+      variables = %{test: "test"}
+
+      assert %Shopify.GraphQL.Operation{query: query, variables: variables} ==
+        Shopify.GraphQL.put_variables(query, variables)
+    end
+
+    test "puts variables when operation is provided" do
+      query = """
+      {
+        shop {
+          name
+        }
+      }
+      """
+
+      operation = %Shopify.GraphQL.Operation{query: query}
+
+      variables = %{test: "test"}
+
+      assert %Shopify.GraphQL.Operation{query: query, variables: variables} ==
+        Shopify.GraphQL.put_variables(operation, variables)
+    end
+
+    test "merges variables" do
+      query = """
+      {
+        shop {
+          name
+        }
+      }
+      """
+
+      operation = %Shopify.GraphQL.Operation{query: query, variables: %{one: "one"}}
+
+      variables = %{two: "two"}
+
+      assert %Shopify.GraphQL.Operation{query: query, variables: %{one: "one", two: "two"}} ==
+        Shopify.GraphQL.put_variables(operation, variables)
+    end
+  end
+
+
   test "sends a POST request" do
     Http.Mock.start_link()
 


### PR DESCRIPTION
Adds a `put_variables/2` public function, which can be used to add multiple variables to the operation at once